### PR TITLE
Noetic : use python3 instead of python3.6

### DIFF
--- a/files/deploy.sh
+++ b/files/deploy.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-# 
+#
 # Copyright 2019 Alexandre Pires (alexandre.pires@mov.ai)
-# 
+#
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at
-# 
+#
 #        http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #    Unless required by applicable law or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-# 
-# File: deploy.sh 
+#
+# File: deploy.sh
 set -e
 
 if [ -f ${APP_PATH}/requirements.txt ]; then
     printf "Installing python dependencies...\n"
     pushd ${APP_PATH} > /dev/null
-    python3.6 -m pip install pip --user --upgrade 
-    python3.6 -m pip install --user --no-cache-dir -r requirements.txt 
+    python3 -m pip install pip --user --upgrade
+    python3 -m pip install --user --no-cache-dir -r requirements.txt
     popd > /dev/null
 fi

--- a/files/update.sh
+++ b/files/update.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-# 
+#
 # Copyright 2019 Alexandre Pires (alexandre.pires@mov.ai)
-# 
+#
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at
-# 
+#
 #        http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #    Unless required by applicable law or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-# 
-# File: deploy.sh 
+#
+# File: deploy.sh
 set -e
 
 UPDATE_FILE=$(ls ${APP_UPDATES}/movai-*_latest_*.deb)
@@ -29,7 +29,7 @@ RETVAL=1
 
 compare_version "${VERSION_CURRENT}" "${VERSION_UPDATE}"
 
-# if the packaged version is greater then the one we have we 
+# if the packaged version is greater then the one we have we
 # do the installation
 if [ ${?} -eq 2 ]; then
 
@@ -64,8 +64,8 @@ if [ ${?} -eq 2 ]; then
     if [ -f ${APP_PATH}/requirements.txt ]; then
         printf "Installing python dependencies...\n"
         pushd ${APP_PATH} >/dev/null
-        python3.6 -m pip install pip --user --upgrade
-        python3.6 -m pip install --user --no-cache-dir -r requirements.txt
+        python3 -m pip install pip --user --upgrade
+        python3 -m pip install --user --no-cache-dir -r requirements.txt
         popd >/dev/null
     fi
 


### PR DESCRIPTION
Noetic is bringing a new version of python3 which is python3.8.x
---
All our python code was made using python 3.6.9, so either we blindly bump to 3.8 and fixes issues on the fly or we stick to python 3.6 in noetic