### PR TITLE
Fix. Even thought its ros free, scripts still require distro env

### DIFF
--- a/melodic/Dockerfile-rosfree
+++ b/melodic/Dockerfile-rosfree
@@ -11,7 +11,8 @@ ARG HEALTH_NODE_URL="http://health-node:8081"
 
 ### Environment config
 ENV MOVAI_HOME="/opt/mov.ai" \
-    ROS_VERSION="melodic"
+    ROS_VERSION="melodic" \
+    ROS_DISTRO="melodic"
 
 ENV APP_PATH="${MOVAI_HOME}/app" \
     APP_LOGS="${MOVAI_HOME}/logs" \

--- a/noetic/Dockerfile-rosfree
+++ b/noetic/Dockerfile-rosfree
@@ -11,7 +11,9 @@ ARG HEALTH_NODE_URL="http://health-node:8081"
 
 ### Environment config
 ENV MOVAI_HOME="/opt/mov.ai" \
-    ROS_VERSION="noetic"
+    ROS_VERSION="noetic" \
+    ROS_DISTRO="noetic"
+
 ENV APP_PATH="${MOVAI_HOME}/app" \
     APP_LOGS="${MOVAI_HOME}/logs" \
     APP_UPDATES="${MOVAI_HOME}/updates" \


### PR DESCRIPTION
Backend now depends on movai-base but this image does not have ROS_DISTRO env. Fixed it.