### PR TITLE
Update to new ROS GPG key

### DIFF
--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -42,8 +42,7 @@ COPY docker/$ROS_VERSION/packages.apt /tmp/packages.apt
 # Install requirements for ppa certificates registration
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt update &&\
-    apt-get install -y curl gnupg --no-install-recommends
+    apt-get update || apt-get install -y --no-install-recommends curl gnupg
 
 COPY files/apt/movai-ubuntu-archive-proxy.list /etc/apt/sources.list.d/movai-ubuntu-archive-proxy.list
 COPY files/apt/movai-ubuntu-ports-proxy.list /etc/apt/sources.list.d/movai-ubuntu-ports-proxy.list
@@ -54,11 +53,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN find /etc/apt/sources.list.d/ -type f -name 'ros*.list' -exec rm {} \; &&\
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
     curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | gpg --dearmor -o /usr/share/keyrings/ros.key &&\
+    apt-key add /usr/share/keyrings/ros.key &&\
     mv /etc/apt/sources.list /etc/apt/sources.list.bck &&\
     touch /etc/apt/sources.list &&\
     curl -fsSL $APT_REPOSITORY/movai-applications/gpg | apt-key add -  &&\
-    if [ "$(uname -m)" = "x86_64" ] ; then rm /etc/apt/sources.list.d/movai-ubuntu-ports-proxy.list ; fi &&\ 
-    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "armv7l" ] ; then rm /etc/apt/sources.list.d/movai-ubuntu-archive* && rm /etc/apt/sources.list.d/movai-ubuntu-security* ; fi &&\ 
+    if [ "$(uname -m)" = "x86_64" ] ; then rm /etc/apt/sources.list.d/movai-ubuntu-ports-proxy.list ; fi &&\
+    if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "armv7l" ] ; then rm /etc/apt/sources.list.d/movai-ubuntu-archive* && rm /etc/apt/sources.list.d/movai-ubuntu-security* ; fi &&\
     apt-get update && apt-get upgrade -y &&\
     /usr/local/bin/install-packages.sh &&\
     apt-get clean &&\

--- a/docker/noetic/Dockerfile
+++ b/docker/noetic/Dockerfile
@@ -42,7 +42,7 @@ COPY docker/$ROS_VERSION/packages.apt /tmp/packages.apt
 # Install requirements for ppa certificates registration
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
-    apt-get update || apt-get install -y --no-install-recommends curl gnupg
+    apt-get update ; apt-get install -y --no-install-recommends curl gnupg
 
 COPY files/apt/movai-ubuntu-archive-proxy.list /etc/apt/sources.list.d/movai-ubuntu-archive-proxy.list
 COPY files/apt/movai-ubuntu-ports-proxy.list /etc/apt/sources.list.d/movai-ubuntu-ports-proxy.list


### PR DESCRIPTION
Fix ROS keys expiration yesterday:

```
movai@a5fb60e84c97:~/app$ gpg --show-keys /usr/share/keyrings/ros.key
gpg: directory '/opt/mov.ai/.gnupg' created
gpg: keybox '/opt/mov.ai/.gnupg/pubring.kbx' created
pub   rsa4096 2019-05-30 [SC] [expired: 2025-06-01]
      C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
uid                      Open Robotics <info@osrfoundation.org>
```

Notes:
- `apt-key add /usr/share/keyrings/ros.key` is forced not to have to update all the sources.list.d files for best retro compatibility